### PR TITLE
Add train ID to departure times table

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -109,6 +109,7 @@ pub(crate) async fn print_times(client: &Client, args: TimesArgs) -> crate::Resu
                 crate::formatting::format_line_name(&train.line),
                 train.destination,
                 crate::formatting::format_last_seen(&train.last_event),
+                train.id,
             ]
         })
         .collect();

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -19,6 +19,7 @@ pub(crate) fn table_basic() -> AsciiTable {
         .column(3)
         .set_header("Last Seen")
         .set_align(Align::Left);
+    table.column(4).set_header("Train").set_align(Align::Left);
 
     table
 }


### PR DESCRIPTION
A useful addition for those wanting to avoid travelling in a dilapidated cattle trailer wherever possible.